### PR TITLE
feat: 初始化配置文件时兼容其他 Sundry 分支/版本

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,9 @@ jobs:
           #     "winget-tools": "上面克隆的位置",
           #     "pkgs-repo": "DuckDuckStudio/winget-pkgs",
           #     "tools-repo": "DuckDuckStudio/winget-tools",
-          #     "signature": "no"
+          #     "signature": "no",
+          #     "fork": "DuckDuckStudio/winget-pkgs",
+          #     "lang": "zh-CN"
           # }
           mkdir -p "$HOME/.config/DuckStudio/Sundry"
           echo "{
@@ -108,7 +110,9 @@ jobs:
             \"winget-tools\": \"D:/a/Sundry/Sundry/winget-tools/\",
             \"pkgs-repo\": \"DuckDuckStudio/winget-pkgs\",
             \"tools-repo\": \"DuckDuckStudio/winget-tools\",
-            \"signature\": \"no\"
+            \"signature\": \"no\",
+            \"fork\": \"DuckDuckStudio/winget-pkgs\",
+            \"lang\": \"zh-CN\"
           }" > "$HOME/.config/DuckStudio/Sundry/config.json"
           cat "$HOME/.config/DuckStudio/Sundry/config.json"
 

--- a/src/tools/maintain/config.py
+++ b/src/tools/maintain/config.py
@@ -15,11 +15,14 @@ def 获取用户输入(键: str):
             "winget-tools": f"{Fore.BLUE}?{Fore.RESET} 您的本地 winget-{Fore.YELLOW}tools{Fore.RESET} 仓库在哪里: "
         },
         "仓库": {
-            "pkgs-repo": f"{Fore.BLUE}?{Fore.RESET} 您的远程 winget-pkgs 仓库是什么: ",
-            "tools-repo": f"{Fore.BLUE}?{Fore.RESET} 您的远程 winget-tools 仓库是什么: "
+            "pkgs-repo": f"{Fore.BLUE}?{Fore.RESET} 您的远程 winget-{Fore.YELLOW}pkgs{Fore.RESET} 仓库是什么: ",
+            "tools-repo": f"{Fore.BLUE}?{Fore.RESET} 您的远程 winget-{Fore.YELLOW}tools{Fore.RESET} 仓库是什么: "
         },
         "签名": {
-            "signature": f"{Fore.BLUE}?{Fore.RESET} 是否要为 Git 提交签名: (默认为{Fore.YELLOW}否{Fore.RESET}): "
+            "signature": f"{Fore.BLUE}?{Fore.RESET} 是否要为 Git 提交签名？(默认为{Fore.YELLOW}否{Fore.RESET}): "
+        },
+        "i18n": {
+            "lang": f"{Fore.BLUE}?{Fore.RESET} 你希望 Sundry 使用哪种语言运行？[{Fore.GREEN}zh-CN(默认){Fore.RESET}, en-US]: "
         }
     }
 
@@ -63,8 +66,22 @@ def 获取用户输入(键: str):
             return "yes"
         else:
             return "no"
+    # Sundry-Locale i18n 分支兼容
+    # i18n输入
+    elif 键 in 提示消息["i18n"]:
+        while True:
+            答案 = input(提示消息["i18n"][键]).lower()
+            if 答案 not in ["", "zh-cn", "en-us"]:
+                print(f"{Fore.RED}✕{Fore.RESET} 不支持的语言，请在 [] 中的语言中选择一种")
+            else:
+                语言映射 = {
+                    "": "zh-CN",
+                    "zh-cn": "zh-CN",
+                    "en-us": "en-US",
+                }
+                return 语言映射.get(答案, "zh-CN")
     else:
-        return input(f"{Fore.BLUE}?{Fore.RESET} 请输入 {键}: ")
+        return input(f"{Fore.BLUE}?{Fore.RESET} 请输入 {键} 的值: ")
 
 # 初始化配置文件
 def 初始化配置文件(配置文件: str):
@@ -84,6 +101,16 @@ def 初始化配置文件(配置文件: str):
             if 键 == "version":
                 continue
             默认配置[键] = 获取用户输入(键)
+
+        if input(f"{Fore.BLUE}? (可选){Fore.RESET} 是否要让配置文件兼容 Sundry-old 和 Sundry-Locale (i18n 分支)？(默认为{Fore.YELLOW}否{Fore.RESET}): ").lower() in ["y", "yes", "要", "是", "true"]:
+            # 往默认配置中添加 key "fork" 值同 "pkgs-repo"
+            # Sundry-old 兼容
+            默认配置["fork"] = 默认配置["pkgs-repo"]
+            # 往默认配置中添加 key "lang" 值 问用户
+            # Sundry-Locale i18n 分支兼容
+            默认配置["lang"] = 获取用户输入("lang")
+
+        # =========================================
 
         if not os.path.exists(os.path.dirname(配置文件)):
             os.makedirs(os.path.dirname(配置文件), exist_ok=True)
@@ -166,7 +193,7 @@ def main(args: list[str]):
             return 修改配置项(条目, 值, 配置文件)
         else:
             print(f"{Fore.RED}✕{Fore.RESET} 无效的操作: {args[0]}")
-            print(f"{Fore.BLUE}[!]{Fore.RESET} 运行 sundry help 来获取命令帮助")
+            print(f"{Fore.BLUE}[!]{Fore.RESET} 运行 sundry --help 来获取命令帮助")
             return 1
     except KeyboardInterrupt:
         print(f"\n{Fore.RED}✕{Fore.RESET} 操作取消")

--- a/src/tools/maintain/config.py
+++ b/src/tools/maintain/config.py
@@ -59,8 +59,7 @@ def 获取用户输入(键: str):
                 print(f"{Fore.RED}✕{Fore.RESET} 请输入正确的仓库格式，例如: owner/repo")
     # 签名输入
     elif 键 in 提示消息["签名"]:
-        答案 = input(提示消息["签名"][键]).lower()
-        if 答案 in ["y", "yes", "要", "是", "true"]:
+        if input(提示消息["签名"][键]).lower() in ["y", "yes", "要", "是", "true"]:
             return "yes"
         else:
             return "no"


### PR DESCRIPTION
### 检查清单
- [x] 有链接Issue吗? -- Resolve #49 <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [x] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Sundry/pulls) 吗?
- [x] 此拉取请求仅针对一个问题/功能吗?
- [x] 你在本地验证过你的修改吗? - https://github.com/DuckDuckStudio/Sundry/issues/49#issuecomment-3064922856
- [x] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

在 `sundry config init` 的最后添加一个可选项，让用户自行决定是否让配置文件兼容 Sundry-old 和 Sundry-Locale (i18n 分支) 的新配置项

之前都是在其中一个 Sundry 上先 init，然后再用 `sundry config 兼容key 值` 来设置兼容的，比较麻烦。

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

