### PR TITLE
ci(build): 将 Windows Runner 定在 windows-2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: 处理版本号


### PR DESCRIPTION
### 检查清单
- [x] 有链接Issue吗? -- Resolve #84 <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [x] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Sundry/pulls) 吗?
- [x] 此拉取请求仅针对一个问题/功能吗?
- [ ] 你在本地验证过你的修改吗?
- [x] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

- 原因见 #82

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

