### PR TITLE
fix(verify): 仅应在清单验证错误时退出

### DIFF
--- a/src/tools/verify.py
+++ b/src/tools/verify.py
@@ -269,7 +269,11 @@ def 验证清单(清单目录: str) -> int:
         # WinGet 会输出清单验证成功
         return 0
     except subprocess.CalledProcessError as e:
-        return e.returncode
+        if e.returncode == 2316632104:
+            # 清单验证成功，但出现警告
+            return 0
+        else:
+            return e.returncode
 
 def 测试安装与卸载(清单目录: str, 操作: str) -> int:
     # 使用 winget install/uninstall --manifest 尝试安装与卸载清单中的程序，并返回 winget 退出代码


### PR DESCRIPTION
### 检查清单
- [x] 有链接Issue吗? -- Resolve #90 <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [x] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Sundry/pulls) 吗?
- [x] 此拉取请求仅针对一个问题/功能吗?
- [x] 你在本地验证过你的修改吗? - 在 Hyper-V win10 上验证
- [x] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

有些清单验证警告并不影响后续测试，例如 InstallerType exe 没有 Silent 开关这些问题都可以忽略。
这里使用退出代码 (2316632104) 来判断是不是警告，如果是则继续测试。

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

