### PR TITLE
test(verify): WinGet 在清单验证阶段实际返回的退出代码似乎和 returnCodes.md 中的退出代码不同，这里添加了一个内部警告来在 WinGet 返回 returnCodes.md 中定义的退出代码时提示我

### DIFF
--- a/src/tools/verify.py
+++ b/src/tools/verify.py
@@ -278,6 +278,9 @@ def 验证清单(清单目录: str) -> int:
         if e.returncode == 2316632104:
             # 清单验证成功，但出现警告
             return 0
+        elif e.returncode == -1978335192:
+            print(f"{消息头.内部警告} WinGet 返回了 returnCodes.md 中的退出代码，也许您应该修改这里的逻辑？")
+            return 0
         else:
             return e.returncode
 


### PR DESCRIPTION
不确定这个修改是否应该合并到 Sundry 中，还是保留在 Sundry-Locale 中就行？