### PR TITLE
feat(config): sundry config edit 快速打开配置文件以供编辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ sundry config "<条目>" "<值>"
 - 示例:
   - 初始化配置: `sundry config init`
   - 显示当前配置: `sundry config show`
+  - 编辑配置文件: `sundry config edit`
   - 修改配置项: `sundry config git.signature false`
   - 更新配置文件: `sundry config update` (当然你直接重新 `init` 一份也可以)
 

--- a/src/tools/maintain/config.py
+++ b/src/tools/maintain/config.py
@@ -4,6 +4,7 @@ import jsonschema
 from typing import Any
 from colorama import init, Fore
 from function.print.print import 消息头
+from function.files.open import open_file
 from pygments import highlight # type: ignore
 from pygments.lexers import JsonLexer # type: ignore
 from pygments.formatters import TerminalFormatter
@@ -290,6 +291,10 @@ def main(args: list[str]) -> int:
             return 展示配置文件(配置文件)
         elif args[0] in ["update", "更新", "upgrade"]:
             return 更新配置()
+        elif args[0] in ["编辑", "edit", "打开", "open"]:
+            print(f"{消息头.信息} 配置文件 config.json 位于 {配置文件}")
+            print(f"{消息头.信息} 尝试打开配置文件 config.json ...")
+            return open_file(配置文件)
         elif len(args) == 2:
             条目 = args[0]
             值 = args[1]


### PR DESCRIPTION
- Resolves https://github.com/DuckDuckStudio/Sundry/issues/174

鉴于 GitHub Action 是无头的，不添加 `sundry config edit` 的测试。