### PR TITLE
feat(func/format/github): 允许使用锚点链接作为 PR 链接

### DIFF
--- a/src/function/format/github.py
+++ b/src/function/format/github.py
@@ -13,12 +13,15 @@ def IssueNumber(输入: str | int | None) -> str | None:
         # 妈的懒到家了
         return str(输入)
     # ===============
+    输入 = 输入.strip()
+    if (not 输入) or (输入 == "0"):
+        return None
     elif 输入.isdigit():
         return 输入
     elif 输入.startswith("#") and 输入[1:].isdigit():
         return 输入[1:]
     elif 输入.startswith("https://"):
-        for path in 输入.split("/"):
+        for path in reversed(输入.split("#", 1)[0].split("/")):
             if path.isdigit():
                 return path
 


### PR DESCRIPTION
其他顺带的
feat: 自动去除输入两头的空白
fix: 无效的 PR 编号 "0" 返回 None
fix: 获取最后一个数字部分而不是第一个，这可以防止将全数字的 owner / repo 当作 PR 编号

- Resolves https://github.com/DuckDuckStudio/Sundry/issues/207