### PR TITLE
fix(func/files/manifest): 在使用 WinGet 处理字体包时需要指定源

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -208,8 +208,8 @@ jobs:
       - name: 测试 - cat
         shell: bash
         run: |-
-          echo "[DEBUG] 运行 python ./Release/src/sundry.py cat DuckStudio.Sundry 1.4.2"
-          python ./Release/src/sundry.py cat DuckStudio.Sundry 1.4.2
+          echo "[DEBUG] 运行 python ./Release/src/sundry.py cat Microsoft.FluentFonts 1.0.0.0"
+          python ./Release/src/sundry.py cat Microsoft.FluentFonts 1.0.0.0
           echo =================================================================
           echo "[DEBUG] 运行 python ./Release/src/sundry.py cat DuckStudio.Sundry 1.4.2 all"
           python ./Release/src/sundry.py cat DuckStudio.Sundry 1.4.2 all


### PR DESCRIPTION
处理方法：
如果在默认源 (winget) 中找不到这个包 (winget 执行失败)，则改为指定字体源 (winget-font)
允许在 debug == True 时显示 WinGet 输出

- Fixes https://github.com/DuckDuckStudio/Sundry/issues/221