### PR TITLE
chore(deps): 固定 catfood 的版本为 1.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-catfood>=1.0.2 # 函数功能和异常
+catfood==1.0.4 # 函数功能和异常
 colorama>=0.4.6 # 输颜色
 jsonschema==4.25.1 # 验证 YAML / JSON
 keyring>=25.6.0 # 读Token


### PR DESCRIPTION
防止 catfood 发布新版本导致 sundry 旧版本出错。