### PR TITLE
feat: 创建的拉取请求正文提及使用的 Sundry 版本

### DIFF
--- a/src/function/constant/general.py
+++ b/src/function/constant/general.py
@@ -12,12 +12,18 @@ InstallerUrl 常见的意外响应类型。
 - html
 """
 
-SUNDRY_VERSION: Final = "locale"
+SUNDRY_VERSION: Final = "develop"
 """
 Sundry 的版本
 """
 
-PR_TOOL_NOTE: Final = f"### This PR is automatically created by [Sundry](https://github.com/DuckDuckStudio/Sundry/)🚀."
+PR_TOOL_NOTE: Final = f"### This PR is automatically created by [Sundry](https://github.com/DuckDuckStudio/Sundry/) {f'{SUNDRY_VERSION} version' if SUNDRY_VERSION in ('develop', 'locale') else f'version {SUNDRY_VERSION}'} 🚀."
 """
-拉取请求正文中的 Sundry 工具说明
+拉取请求正文中的 Sundry 工具说明。
+
+- 特殊版本
+### This PR is automatically created by [Sundry](https://github.com/DuckDuckStudio/Sundry/) locale/develop version 🚀.
+
+- 一般版本
+### This PR is automatically created by [Sundry](https://github.com/DuckDuckStudio/Sundry/) version x.x.x 🚀.
 """


### PR DESCRIPTION
效果示例
<img width="743" height="172" alt="image" src="https://github.com/user-attachments/assets/58cc2c6c-ad77-4a86-a702-2de4681522bf" />


此拉取请求也更正了常量中的版本（`locale` -> `develop`）