### PR TITLE
fix(func/files/manifest): 对获取清单目录函数添加更多检查和调试输出

### DIFF
--- a/src/function/files/manifest.py
+++ b/src/function/files/manifest.py
@@ -50,6 +50,11 @@ def 获取清单目录(包标识符: str, 包版本: str | None = None, winget_p
     :rtype: str | None
     """
 
+    if '.' not in 包标识符:
+        if 读取配置("debug"):
+            print(f"{消息头.调试} 包标识符格式不正确（应带有 \'.\'），获取到 {包标识符}")
+        return None
+
     if not winget_pkgs目录:
         配置值 = 读取配置("paths.winget-pkgs")
         if isinstance(配置值, str):
@@ -61,8 +66,19 @@ def 获取清单目录(包标识符: str, 包版本: str | None = None, winget_p
         清单目录 = os.path.join(winget_pkgs目录, 包类型, 包标识符[0].lower(), *包标识符.split('.'))
         if 包版本:
             清单目录 = os.path.join(清单目录, 包版本)
-        if os.path.exists(清单目录):
-            return 清单目录
+
+        if not os.path.exists(清单目录):
+            if 读取配置("debug"):
+                print(f"{消息头.调试} 未能在 {包类型} 目录下找到清单目录")
+            continue
+
+        if 包版本 and any(os.path.isdir(os.path.join(清单目录, item)) for item in os.listdir(清单目录)):
+            if 读取配置("debug"):
+                print(f"{消息头.调试} 目录 {os.path.relpath(清单目录, winget_pkgs目录)} 下存在其他文件夹，不是版本文件夹")
+                print(f"{消息头.提示} 这可能是因为你 {Fore.YELLOW}错误的将包标识符的一部分当作包版本{Fore.RESET} 导致的，也可能是因为 {包类型} 目录下也有标识符部分相同的包")
+            continue
+
+        return 清单目录
 
     return None
         

--- a/src/function/files/manifest.py
+++ b/src/function/files/manifest.py
@@ -57,9 +57,7 @@ def 获取清单目录(包标识符: str, 包版本: str | None = None, winget_p
         else:
             return None
 
-    可能的包类型 = ["manifests", "fonts"]
-
-    for 包类型 in 可能的包类型:
+    for 包类型 in ("manifests", "fonts"):
         清单目录 = os.path.join(winget_pkgs目录, 包类型, 包标识符[0].lower(), *包标识符.split('.'))
         if 包版本:
             清单目录 = os.path.join(清单目录, 包版本)

--- a/src/tools/cat.py
+++ b/src/tools/cat.py
@@ -72,13 +72,6 @@ def main(args: list[str]) -> int:
         print(f"{消息头.错误} 获取清单目录失败")
         return 1
 
-    if any(os.path.isdir(os.path.join(清单目录, item)) for item in os.listdir(清单目录)):
-        # 如果清单目录下存在其他文件夹
-        print(f"{消息头.错误} 清单目录下存在其他文件夹")
-        print(f"{消息头.提示} 这可能是因为你 {Fore.YELLOW}错误的将包标识符的一部分当作包版本{Fore.RESET} 导致的。")
-        print(f"{消息头.提示} 例如包 DuckStudio.GitHubView.Nightly 被错误的认为是包 DuckStudio.GitHubView 的一个版本号为 Nightly 的版本。")
-        return 1
-
     清单文件: list[str] | str
     if (清单类型 == "all"):
         # 设置清单文件为清单目录下的所有 yaml 文件

--- a/src/tools/remove.py
+++ b/src/tools/remove.py
@@ -102,13 +102,6 @@ def main(args: list[str]) -> int:
         print(f"{Fore.RED}包版本清单目录不存在: {os.path.join(清单目录, 包版本)}")
         return 1
 
-    if any(os.path.isdir(os.path.join(os.path.join(清单目录, 包版本), item)) for item in os.listdir(os.path.join(清单目录, 包版本))):
-        # 如果包版本清单目录下存在其他文件夹
-        print(f"{消息头.错误} 包版本清单目录下存在其他文件夹")
-        print(f"{消息头.提示} 这可能是因为你 {Fore.YELLOW}错误的将包标识符的一部分当作包版本{Fore.RESET} 导致的。")
-        print(f"{消息头.提示} 例如包 DuckStudio.GitHubView.Nightly 被错误的认为是包 DuckStudio.GitHubView 的一个版本号为 Nightly 的版本。")
-        return 1
-
     # 入口
     os.chdir(winget_pkgs目录)
     if not 跳过检查:


### PR DESCRIPTION
添加的检查：
1. 包标识符中必须含有 `.`
2. 版本目录下不能有其他目录

同时移除 cat 和 remove 中对 检查 2 的重复检查