### PR TITLE
refactor(func/gh/token): 统一改用 catfood.functions.github.api 的 这是谁的Token 函数

### DIFF
--- a/src/function/github/token.py
+++ b/src/function/github/token.py
@@ -1,9 +1,9 @@
-from colorama import Fore
-from typing import cast, Any
-from catfood.functions.print import 消息头
-from function.maintain.config import 读取配置
-from catfood.functions.github.api import 请求GitHubAPI
 from catfood.exceptions.operation import OperationFailed
+from catfood.functions.print import 消息头
+from colorama import Fore
+
+from function.maintain.config import 读取配置
+
 
 def read_token(silent: bool = False) -> str | None:
     """尝试从配置文件中指定的源读取 Token，读取失败返回 None"""
@@ -27,7 +27,7 @@ def read_token(silent: bool = False) -> str | None:
                 service_name, username = ("github-access-token.komac", "github-access-token")
             else:
                 raise OperationFailed(f"未知的读取源 {source}")
-         
+
             if token := keyring.get_password(service_name, username):
                 return token
             else:
@@ -35,19 +35,4 @@ def read_token(silent: bool = False) -> str | None:
     except OperationFailed as e:
         if not silent:
             print(f"{消息头.错误} 读取 Token 失败: {Fore.RED}{e}{Fore.RESET}")
-        return None
-
-def 这是谁的Token(token: str | int | None) -> str | None:
-    """
-    通过 GitHub API 来确认这个 Token 是谁的，失败返回 None。
-    """
-
-    if not isinstance(token, str):
-        return None
-    响应 = 请求GitHubAPI("https://api.github.com/user", token=token)
-    响应 = cast(dict[str, Any], 响应)
-    谁的 = 响应.get("login", None)
-    if isinstance(谁的, str):
-        return 谁的
-    else:
         return None

--- a/src/tools/modify.py
+++ b/src/tools/modify.py
@@ -1,23 +1,27 @@
-import os
-import sys
 import csv
-import time
+import os
 import random
-import requests
 import subprocess
-from colorama import Fore
+import sys
+import time
 from datetime import datetime
-from catfood.constant import YES
-from catfood.functions.print import 消息头
-from function.git.format import branchName
-from function.maintain.config import 读取配置
-from catfood.functions.files import open_file
-from function.files.manifest import 获取清单目录
-from function.files.manifest import FormatManifest
-from function.constant.general import PR_TOOL_NOTE
-from function.github.token import read_token, 这是谁的Token
+from typing import Literal
 
-def main(args: list[str]):
+import requests
+from catfood.constant import YES
+from catfood.functions.files import open_file
+from catfood.functions.github.api import 这是谁的Token
+from catfood.functions.print import 消息头
+from colorama import Fore
+
+from function.constant.general import PR_TOOL_NOTE
+from function.files.manifest import FormatManifest, 获取清单目录
+from function.git.format import branchName
+from function.github.token import read_token
+from function.maintain.config import 读取配置
+
+
+def main(args: list[str]) -> Literal[1] | Literal[0]:
     global 包标识符, 包版本, 日志文件路径
     global 解决, 清单目录, 首个_PR, 格式化审查者, 程序所在目录
     global owner
@@ -39,7 +43,7 @@ def main(args: list[str]):
     else:
         print(f"{消息头.错误} {Fore.RED}参数错误，使用 sundry help 来查看帮助{Fore.RESET}")
         return 1
-    
+
     # 路径
     程序所在目录 = os.path.dirname(os.path.abspath(sys.argv[0]))
     日志文件路径 = os.path.join("logs", datetime.today().strftime('%Y\\%m\\%d'), f"{包标识符}-{包版本}.log") # 相对路径
@@ -48,7 +52,7 @@ def main(args: list[str]):
     winget_pkgs目录 = 读取配置("paths.winget-pkgs")
     if not isinstance(winget_pkgs目录, str):
         return 1
-    
+
     pkgs仓库 = 读取配置("repos.winget-pkgs")
     if not isinstance(pkgs仓库, tuple):
         return 1

--- a/src/tools/remove.py
+++ b/src/tools/remove.py
@@ -1,24 +1,28 @@
-import re
-import os
 import csv
-import time
+import os
+import re
 import shutil
-import tempfile
-import requests
 import subprocess
+import tempfile
+import time
 import webbrowser
+
+import requests
+from catfood.constant import NO, YES
+from catfood.exceptions.operation import OperationFailed
+from catfood.functions.github.api import 这是谁的Token
+from catfood.functions.print import 消息头
+from colorama import Fore
+from translate import Translator  # type: ignore
+
 import tools.cat as cat
 import tools.sync as sync
-from colorama import Fore
-from catfood.constant import YES, NO
-from catfood.functions.print import 消息头
-from function.git.format import branchName
-from function.maintain.config import 读取配置
-from translate import Translator # type: ignore
 from function.constant.general import PR_TOOL_NOTE
-from catfood.exceptions.operation import OperationFailed
-from function.github.token import read_token, 这是谁的Token
 from function.files.manifest import 获取清单目录, 获取现有包版本
+from function.git.format import branchName
+from function.github.token import read_token
+from function.maintain.config import 读取配置
+
 
 # 创建拉取请求
 def 创建拉取请求(包标识符: str, 分支名: str, 版本文件夹: str, 理由: str):


### PR DESCRIPTION
而不是自己另在 function.github.token 里起一个同名函数
