### PR TITLE
chore(pyproject): 修改最大行长

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,11 @@ dependencies = [
 ]
 
 [tool.isort]
-line_length = 9999999999999999999999999 # 约等于无行长度限制
+line_length = 200
 
 [tool.pylint.main]
 init-hook = 'import sys; sys.path.append("src")'
-max-line-length = 9999999999999999999999999 # 约等于无行长度限制
+max-line-length = 200
 notes= [
     "FIXME",
     "XXX"


### PR DESCRIPTION
值太大 uv 会解析失败

```
└─> uv sync
Using CPython 3.14.5 interpreter at: C:\Users\...\AppData\Local\Python\pythoncore-3.14-64\python.exe
Creating virtual environment at: .venv
  × Failed to build `sundry @ file:///D:/.../Sundry`
  ├─▶ Failed to parse metadata from built wheel
  ├─▶ Invalid `pyproject.toml`
  ╰─▶ TOML parse error at line 21, column 15
         |
      21 | line_length = 9999999999999999999999999 # 约等于无行长度限制
         |               ^^^^^^^^^^^^^^^^^^^^^^^^^
      integer number overflowed
```