### PR TITLE
chore(dev-deps): 移除当前不需要的测试依赖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,3 @@ lint = [
     "pylint~=4.0",
     "ruff~=0.15"
 ]
-tests = [
-    "pytest~=9.0",
-    "pytest-cov~=7.1"
-]


### PR DESCRIPTION
- Resolves #327
