### PR TITLE
ci(build): 移除下载 ChineseSimplified.isl 的时间限制

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,16 +119,11 @@ jobs:
       - name: 打包安装程序
         shell: pwsh
         run: |-
-          if ((Get-Date) -le (Get-Date "2026-06-29")) {
-            Write-Host "通过 GitHub API 下载中文翻译..."
-            $apiUrl = "https://api.github.com/repos/jrsoftware/issrc/contents/Files/Languages/ChineseSimplified.isl?ref=main"
-            $downloadPath = "C:\Program Files (x86)\Inno Setup 6\Languages\ChineseSimplified.isl"
-            Invoke-WebRequest -Uri $apiUrl -Headers @{ "Accept" = "application/vnd.github.raw+json" } -OutFile $downloadPath
-            Get-FileHash -Path $downloadPath -Algorithm SHA256
-          } else {
-            Write-Error "Inno Setup 7.0.2 应该今天会发布，请使用包含官方翻译的新版本"
-            exit -1
-          }
+          Write-Host "通过 GitHub API 下载中文翻译..."
+          $apiUrl = "https://api.github.com/repos/jrsoftware/issrc/contents/Files/Languages/ChineseSimplified.isl?ref=main"
+          $downloadPath = "C:\Program Files (x86)\Inno Setup 6\Languages\ChineseSimplified.isl"
+          Invoke-WebRequest -Uri $apiUrl -Headers @{ "Accept" = "application/vnd.github.raw+json" } -OutFile $downloadPath
+          Get-FileHash -Path $downloadPath -Algorithm SHA256
 
           iscc installer.iss
 


### PR DESCRIPTION
现在已经是 7 月了，他们还没发布新版本。

https://github.com/jrsoftware/issrc/commit/4adb2ab4728163f7c35f1c3e234d8e168e5ef8d3

好吧，七月十三。

---

测试运行：https://github.com/DuckDuckStudio/Sundry/actions/runs/28535829192