### PR TITLE
ci(build): 在上传发布文件时指定仓库

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -158,4 +158,4 @@ jobs:
       - name: 发布至发行版
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$env:GITHUB_REF_NAME" "Release/*"
+        run: gh release upload "$env:GITHUB_REF_NAME" "Release/*" -R "DuckDuckStudio/Sundry"


### PR DESCRIPTION
没有指定的话会因为 Release 目录不是 .git 目录，gh 不知道传哪里。
