### PR TITLE
chore(dev-deps): 添加 basedpyright、ty 作为 lint 依赖项

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,9 @@ build = [
     "pyinstaller==6.21.0"
 ]
 lint = [
+    "basedpyright~=1.39.8",
     "isort~=8.0",
     "pylint~=4.0",
-    "ruff~=0.15"
+    "ruff~=0.15",
+    "ty~=0.0.54",
 ]


### PR DESCRIPTION
主要是 PyCharm 支持这两个。

