### PR TITLE
fix(func/constant/logsAnalyse): 修正当解释没有指定颜色时，获取带颜色的解释内容会得到 "None{内容}" 的问题

### DIFF
--- a/src/function/constant/logsAnalyse.py
+++ b/src/function/constant/logsAnalyse.py
@@ -28,11 +28,16 @@ class Explanation:
 
     def get_colored_message(self) -> str:
         """
-        获取带颜色的解释内容
+        获取带颜色的解释内容。
 
         Returns:
-            str: 带颜色的解释内容
+            str:
+                带颜色的解释内容；
+                如果该解释没有指定颜色，则原样返回解释内容。
         """
+
+        if self.color is None:
+            return self.message
 
         return f"{self.color}{self.message}{Fore.RESET}"
 


### PR DESCRIPTION
<img width="330" height="230" alt="图片" src="https://github.com/user-attachments/assets/bd42dc93-db4e-493f-b63b-a2466c33a8d1" />
