### PR TITLE
chore(deps): 提升 ajaw 依赖要求 ~=1.0.0 → ~=1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "ajaw~=1.0.0",
+    "ajaw~=1.0.1",
     "catfood==2.2.1",
     "colorama>=0.4.6",
     "jsonschema==4.26.0",

--- a/src/sundry.py
+++ b/src/sundry.py
@@ -10,10 +10,7 @@ from function.constant.paths import SUNDRY_LOCATION
 
 def main() -> int:
     init(autoreset=True)
-    try:
-        ajaw.load_translations()
-    except FileNotFoundError:
-        pass
+    ajaw.load_translations()
 
     try:
         tool = sys.argv[1].lower()


### PR DESCRIPTION
在 ajaw 1.0.1 之后，不会再直接抛出 `FileNotFoundError`，不再需要捕获这个异常。
详见：https://github.com/DuckDuckStudio/ajaw/releases/tag/1.0.1